### PR TITLE
PGN parser enhancements

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -68,22 +68,23 @@ printMove (End result) = do
   putStrLn ""
   putStr "      "
   printResult result
-printMove (Move n c p nx vs) = do
+printMove (HalfMove n c d as nx vs) = do
   case c of
     White -> do
       putStrLn ""
       putStr "  "
       printMoveNumber n
     Black -> return ()
-  printPly p
+  printDescription d
+  printAnnotations as
   unless (null vs) $ do
     printVariants vs
   case c of
-    White -> if hasAnnotations p
-             then do
+    White -> if null as
+             then putStr " "
+             else do
                putStrLn ""
                putStr $ lpad (2 + 4 + 11 + 1) ""
-             else putStr " "
     Black -> return ()
   printMove nx
 
@@ -101,10 +102,8 @@ printResult _         = putStrLn "uncertain"
 printMoveNumber :: Int -> IO ()
 printMoveNumber n = putStr $ lpad 4 (show n ++ ". ")
 
-printPly :: Ply -> IO ()
-printPly (Ply m annotations) = do
-  putStr (lpad 11 m)
-  printAnnotations annotations
+printDescription :: String -> IO ()
+printDescription description = putStr (lpad 11 description)
 
 printAnnotations :: [Annotation] -> IO ()
 printAnnotations [] = return ()

--- a/examples/7.pgn
+++ b/examples/7.pgn
@@ -1,0 +1,17 @@
+[Event "Hourly SuperBlitz Arena"]
+[Site "https://lichess.org/EGwCvm63"]
+[Date "2015.12.30"]
+[White "oleg33el"]
+[Black "ptitfred"]
+[Result "0-1"]
+[WhiteElo "1520"]
+[BlackElo "1453"]
+[PlyCount "0"]
+[Variant "Standard"]
+[TimeControl "180+0"]
+[ECO "?"]
+[Opening "?"]
+[Termination "Abandoned"]
+[Annotator "lichess.org"]
+
+0-1

--- a/src/PGN.hs
+++ b/src/PGN.hs
@@ -11,7 +11,6 @@ module PGN
     , ResultValue(..)
     , parseFile
     , hasAnnotations
-    , variant
     ) where
 
 import qualified Control.Applicative as A ((<|>))
@@ -20,7 +19,7 @@ import Text.Parsec
 import Text.Parsec.ByteString (Parser, parseFromFile)
 
 parseFile :: FilePath -> IO (Either ParseError Match)
-parseFile file = parseFromFile match file
+parseFile file = parseFromFile parseMatch file
 
 data Match = Match { matchHeaders :: [Header]
                    , matchMoves   :: Move
@@ -47,26 +46,33 @@ data Header = Event String
 
 data Color = White | Black deriving (Show)
 
-data Move = Move { number   :: Int
-                 , color    :: Color
-                 , ply      :: Ply
-                 , next     :: Move
-                 , variants :: [Move]
+data Move = Move { moveNumber   :: Int
+                 , moveColor    :: Color
+                 , movePly      :: Ply
+                 , moveNext     :: Move
+                 , moveVariants :: [Move]
                  }
           | End ResultValue
           | VariantEnd
            deriving (Show)
 
-data Ply = Ply String [Annotation] deriving (Show)
+data Ply = Ply { plyDescription :: String
+               , plyAnnotations :: [Annotation]
+               } deriving (Show)
 
 hasAnnotations :: Ply -> Bool
 hasAnnotations (Ply _ []) = False
 hasAnnotations _          = True
 
 data Annotation = GlyphAnnotation Glyph | CommentAnnotation Comment deriving (Show)
-
 newtype Glyph = Glyph Int deriving (Show)
 type Comment = String
+
+mkAnnotations :: Maybe Glyph -> [Comment] -> [Annotation]
+mkAnnotations g cs = mkGlyphAnnotation g ++ mkCommentAnnotations cs
+  where mkGlyphAnnotation Nothing   = []
+        mkGlyphAnnotation (Just g') = [GlyphAnnotation g']
+        mkCommentAnnotations = map CommentAnnotation
 
 data ResultValue = WhiteWins | BlackWins | Draw | Unknown deriving (Show)
 
@@ -76,79 +82,87 @@ readResultValue "0-1"     = BlackWins
 readResultValue "1/2-1/2" = Draw
 readResultValue _         = Unknown
 
-parseHeader :: String -> String -> Header
-parseHeader "Event"       = Event
-parseHeader "Site"        = Site
-parseHeader "Date"        = Date
-parseHeader "Round"       = Round
-parseHeader "White"       = WhitePlayer
-parseHeader "Black"       = BlackPlayer
-parseHeader "Result"      = Result . readResultValue
-parseHeader "WhiteElo"    = WhiteElo . read
-parseHeader "BlackElo"    = BlackElo . read
-parseHeader "PlyCount"    = PlyCount
-parseHeader "Variant"     = Variant
-parseHeader "TimeControl" = TimeControl
-parseHeader "ECO"         = ECO
-parseHeader "Opening"     = Opening
-parseHeader "Termination" = Termination
-parseHeader "Annotator"   = Annotator
-parseHeader h             = Other h
+readHeader :: String -> String -> Header
+readHeader "Event"       = Event
+readHeader "Site"        = Site
+readHeader "Date"        = Date
+readHeader "Round"       = Round
+readHeader "White"       = WhitePlayer
+readHeader "Black"       = BlackPlayer
+readHeader "Result"      = Result . readResultValue
+readHeader "WhiteElo"    = WhiteElo . read
+readHeader "BlackElo"    = BlackElo . read
+readHeader "PlyCount"    = PlyCount
+readHeader "Variant"     = Variant
+readHeader "TimeControl" = TimeControl
+readHeader "ECO"         = ECO
+readHeader "Opening"     = Opening
+readHeader "Termination" = Termination
+readHeader "Annotator"   = Annotator
+readHeader h             = Other h
 
-match :: Parser Match
-match = Match <$> headers <*> (spaces *> move 0 <* spaces <* eof)
+parseMatch :: Parser Match
+parseMatch = Match <$> parseHeaders <*> parseFirstMove
 
-move :: Int -> Parser Move
-move n = do
-  v <- optionMaybe (VariantEnd <$ try (spaces *> char ')'))
-  if isJust v
-  then return $ fromJust v
-  else do
-    r <- result
-    if isJust r
-    then return $ fromJust r
-    else do
-      spaces
-      n' <- fromMaybe n <$> moveNumber
-      let color' = if n' > n
-                   then White
-                   else Black
-      somePly <- ply'
-      vs <- variants' n'
-      continuation n'
-      spaces
-      next' <- move n'
-      return $ Move n' color' somePly next' vs
+parseFirstMove :: Parser Move
+parseFirstMove = spaces *> parseMove 0 <* spaces <* eof
 
-ply' :: Parser Ply
-ply' = do
-  m <- many1 (oneOf "abcdefgh12345678NBRQKx+#=O-")
-  glyph1 <- optionMaybe traditionalGlyph <* spaces
-  glyph2 <- optionMaybe glyph <* spaces
-  comments <- many (try (comment <* spaces))
-  let glyph' = glyph1 A.<|> glyph2
-  let annotations = mkAnnotations glyph' comments
-  return $ Ply m annotations
+parseMove :: Int -> Parser Move
+parseMove m = eithers [parseVariantEnd, parseResult] (parsePieceMove m)
 
-mkAnnotations :: Maybe Glyph -> [Comment] -> [Annotation]
-mkAnnotations g cs = mkGlyphAnnotation g ++ mkCommentAnnotations cs
+parseResult :: Parser (Maybe Move)
+parseResult = (fmap (End . readResultValue)) <$> optionMaybe parseResultValue
+  where parseResultValue = tries [ string "1/2-1/2"
+                                 , string "1-0"
+                                 , string "0-1"
+                                 , string "*"
+                                 ]
 
-mkGlyphAnnotation :: Maybe Glyph -> [Annotation]
-mkGlyphAnnotation Nothing = []
-mkGlyphAnnotation (Just g) = [GlyphAnnotation g]
+parseVariantEnd :: Parser (Maybe Move)
+parseVariantEnd = optionMaybe (VariantEnd <$ try (spaces *> char ')'))
 
-mkCommentAnnotations :: [Comment] -> [Annotation]
-mkCommentAnnotations = map CommentAnnotation
+parsePieceMove :: Int -> Parser Move
+parsePieceMove previousNumber = do
+  number   <- spaces *> parseMoveNumber previousNumber
+  ply      <- parsePly
+  variants <- parseVariants number
+  parseContinuation number <* spaces
+  next     <- parseMove number
+  return $ Move { moveNumber   = number
+                , moveColor    = chooseColor (number > previousNumber)
+                , movePly      = ply
+                , moveNext     = next
+                , moveVariants = variants
+                }
 
-continuation :: Int -> Parser ()
-continuation m = () <$ optionMaybe (try (string (show m) <* string "..."))
+chooseColor :: Bool -> Color
+chooseColor True  = White
+chooseColor False = Black
 
-glyph :: Parser Glyph
-glyph = (Glyph . read) <$> try (char '$' *> many1 digit)
-     <|> traditionalGlyph
+parsePly :: Parser Ply
+parsePly = do
+  description <- parsePlyDescription
+  glyph1      <- optionMaybe parseLitteralGlyph <* spaces
+  glyph2      <- optionMaybe parseGlyph <* spaces
+  comments    <- parseComments
+  return $ Ply { plyDescription = description
+               , plyAnnotations = mkAnnotations (glyph1 A.<|> glyph2) comments
+               }
 
-traditionalGlyph :: Parser Glyph
-traditionalGlyph =
+parsePlyDescription :: Parser String
+parsePlyDescription = many1 (oneOf "abcdefgh12345678NBRQKx+#=O-")
+
+parseContinuation :: Int -> Parser ()
+parseContinuation m = () <$ optionMaybe (try (string (show m) <* string "..."))
+
+parseGlyph :: Parser Glyph
+parseGlyph = parseNumericAnnotationGlyph <|> parseLitteralGlyph
+
+parseNumericAnnotationGlyph :: Parser Glyph
+parseNumericAnnotationGlyph = (Glyph . read) <$> try (char '$' *> many1 digit)
+
+parseLitteralGlyph :: Parser Glyph
+parseLitteralGlyph =
   tries
     [ "!!"   `toGlyph`  3
     , "??"   `toGlyph`  4
@@ -164,43 +178,49 @@ traditionalGlyph =
     where toGlyph :: String -> Int -> Parser Glyph
           toGlyph text g = Glyph g <$ string text
 
-variants' :: Int -> Parser [Move]
-variants' m = many (try (variant m) <* spaces)
+parseVariants :: Int -> Parser [Move]
+parseVariants m = many (try (parseVariant m) <* spaces)
 
-variant :: Int -> Parser Move
-variant m = char '(' *> continuation m *> spaces *> move m <* spaces
+parseVariant :: Int -> Parser Move
+parseVariant m = char '(' *> parseContinuation m *> spaces *> parseMove m <* spaces
 
-tries :: [Parser a] -> Parser a
-tries = choice . map try
+parseComments :: Parser [Comment]
+parseComments = many (try (parseComment <* spaces))
 
-comment :: Parser Comment
-comment = char '{' *> spaces *> manyTill anyChar (try (spaces >> char '}'))
+parseComment :: Parser Comment
+parseComment = char '{' *> spaces *> manyTill anyChar (try (spaces >> char '}'))
 
-moveNumber :: Parser (Maybe Int)
-moveNumber = (fmap read) <$> optionMaybe (try (many1 digit <* char '.' <* spaces))
+parseMoveNumber :: Int -> Parser Int
+parseMoveNumber m = (fromMaybe m . fmap read) <$> optionMaybe (try (many1 digit <* char '.' <* spaces))
 
-result :: Parser (Maybe Move)
-result = (fmap (End . readResultValue)) <$> optionMaybe (tries [string "1/2-1/2", string "1-0", string "0-1", string "*"])
+parseHeaders :: Parser [Header]
+parseHeaders = many parseHeader <* newline
+
+parseHeader :: Parser (Header)
+parseHeader = char '[' *> parseHeaderContent <* char ']' <* newline
+
+parseHeaderContent :: Parser (Header)
+parseHeaderContent = readHeader <$> parseHeaderName <* spaces <*> parseHeaderValue
+
+parseHeaderName :: Parser String
+parseHeaderName = many (noneOf " ")
+
+parseHeaderValue :: Parser String
+parseHeaderValue = textBetween '"' '"'
+
+{- Utilities -}
 
 textBetween :: Char -> Char -> Parser String
 textBetween c1 c2 = between (char c1) (char c2) (content)
   where content = many (noneOf [c2])
 
-headers :: Parser [Header]
-headers = many header <* newline
+eithers :: [Parser (Maybe a)] -> Parser a -> Parser a
+eithers [] main = main
+eithers (alt:alts) main = do
+  v <- alt
+  if isJust v
+  then return $ fromJust v
+  else eithers alts main
 
-header :: Parser (Header)
-header = char '[' *> headerContent <* char ']' <* newline
-
-headerContent :: Parser (Header)
-headerContent = do
-  name  <- headerName
-  _     <- char ' '
-  value <- headerValue
-  return $ parseHeader name value
-
-headerName :: Parser String
-headerName = many (noneOf " ")
-
-headerValue :: Parser String
-headerValue = textBetween '"' '"'
+tries :: [Parser a] -> Parser a
+tries = choice . map try


### PR DESCRIPTION
- Normalize functions names
- `Ply` is now part of `HalfMove` (previously called `Move`)

Bonus: example of match with no move (forfeit)
